### PR TITLE
symlink hosts file

### DIFF
--- a/vagrant/apache/hosts
+++ b/vagrant/apache/hosts
@@ -1,2 +1,1 @@
-10.19.136.142 content.server.lcl
-
+../hosts


### PR DESCRIPTION
Make the 'hosts' files in the Dockerfile directory point to the
'hosts' file outside the directory. Rather than update it in many
places this will allow us to update the ip/hostname mapping in only
one place.